### PR TITLE
Added Ollama support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Edit config.py to select the models you want to use:
     class Config:
         # Model selection
         TRANSCRIPTION_MODEL = 'groq'  # Options: 'openai', 'groq', 'deepgram', 'fastwhisperapi' 'local'
-        RESPONSE_MODEL = 'groq'       # Options: 'openai', 'groq', 'local'
+        RESPONSE_MODEL = 'groq'       # Options: 'openai', 'groq', 'ollama', 'local'
         TTS_MODEL = 'deepgram'        # Options: 'openai', 'deepgram', 'elevenlabs', 'local', 'melotts'
 
         # API keys and paths
@@ -178,6 +178,7 @@ Edit config.py to select the models you want to use:
 
 - **OpenAI**: Uses OpenAI's GPT-4 model.
 - **Groq**: Uses Groq's LLaMA model.
+- **Ollama**: Uses any model served via Ollama.
 - **Local**: Placeholder for a local language model.
 
 #### Text-to-Speech (TTS) Models  🔊

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Edit config.py to select the models you want to use:
         LOCAL_MODEL_PATH = os.getenv("LOCAL_MODEL_PATH")
 ```
 
+If you are running LLM locally via [Ollama](https://ollama.com/), make sure the Ollama server is runnig before starting verbi. 
+
 6. 🔊 **Configure ElevenLabs Jarvis' Voice**
 - Voice samples [here](https://github.com/PromtEngineer/Verbi/tree/main/voice_samples).
 - Follow this [link](https://elevenlabs.io/app/voice-lab/share/de3746fa51a09e771604d74b5d1ff6797b6b96a5958f9de95cef544dde31dad9/WArWzu0z4mbSyy5BfRKM) to add the Jarvis voice to your ElevenLabs account.

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ numpy
 sounddevice 
 cartesia
 soundfile
+ollama

--- a/voice_assistant/config.py
+++ b/voice_assistant/config.py
@@ -22,12 +22,16 @@ class Config:
     """
     # Model selection
     TRANSCRIPTION_MODEL = 'deepgram'  # possible values: openai, groq, deepgram, fastwhisperapi
-    RESPONSE_MODEL = 'groq'       # possible values: openai, groq
-    TTS_MODEL = 'elevenlabs'        # possible values: openai, deepgram, elevenlabs, melotts, cartesia
+    RESPONSE_MODEL = 'ollama'  # possible values: openai, groq, ollama
+    TTS_MODEL = 'deepgram'  # possible values: openai, deepgram, elevenlabs, melotts, cartesia
 
     # currently using the MeloTTS for local models. here is how to get started:
     # https://github.com/myshell-ai/MeloTTS/blob/main/docs/install.md#linux-and-macos-install
 
+    # LLM Selection
+    OLLAMA_LLM="llama3:8b"
+    GROQ_LLM="llama3-8b-8192"
+    OPENAI_LLM="gpt-4o"
 
     # API keys and paths
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -53,7 +57,7 @@ class Config:
         """
         if Config.TRANSCRIPTION_MODEL not in ['openai', 'groq', 'deepgram', 'fastwhisperapi', 'local']:
             raise ValueError("Invalid TRANSCRIPTION_MODEL. Must be one of ['openai', 'groq', 'deepgram', 'fastwhisperapi', 'local']")
-        if Config.RESPONSE_MODEL not in ['openai', 'groq', 'local']:
+        if Config.RESPONSE_MODEL not in ['openai', 'groq', 'ollama', 'local']:
             raise ValueError("Invalid RESPONSE_MODEL. Must be one of ['openai', 'groq', 'local']")
         if Config.TTS_MODEL not in ['openai', 'deepgram', 'elevenlabs', 'melotts', 'cartesia', 'local']:
             raise ValueError("Invalid TTS_MODEL. Must be one of ['openai', 'deepgram', 'elevenlabs', 'melotts', 'cartesia', 'local']")
@@ -69,6 +73,7 @@ class Config:
             raise ValueError("OPENAI_API_KEY is required for OpenAI models")
         if Config.RESPONSE_MODEL == 'groq' and not Config.GROQ_API_KEY:
             raise ValueError("GROQ_API_KEY is required for Groq models")
+
 
         if Config.TTS_MODEL == 'openai' and not Config.OPENAI_API_KEY:
             raise ValueError("OPENAI_API_KEY is required for OpenAI models")

--- a/voice_assistant/response_generation.py
+++ b/voice_assistant/response_generation.py
@@ -2,7 +2,10 @@
 
 from openai import OpenAI
 from groq import Groq
+import ollama
 import logging
+from voice_assistant.config import Config
+
 
 def generate_response(model, api_key, chat_history, local_model_path=None):
     """
@@ -21,17 +24,24 @@ def generate_response(model, api_key, chat_history, local_model_path=None):
         if model == 'openai':
             client = OpenAI(api_key=api_key)
             response = client.chat.completions.create(
-                model="gpt-4o",
+                model=Config.OPENAI_LLM,
                 messages=chat_history
             )
             return response.choices[0].message.content
         elif model == 'groq':
             client = Groq(api_key=api_key)
             response = client.chat.completions.create(
-                model="llama3-8b-8192",
+                model=Config.GROQ_LLM, #"llama3-8b-8192",
                 messages=chat_history
             )
             return response.choices[0].message.content
+        elif model == 'ollama':
+            response = ollama.chat(
+                model=Config.OLLAMA_LLM,
+                messages=chat_history,
+                # stream=True,
+            )
+            return response['message']['content']
         elif model == 'local':
             # Placeholder for local LLM response generation
             return "Generated response from local model"


### PR DESCRIPTION
Added support for using local models via Ollama. 

- Now you can set the `RESPONSE_MODEL` to `ollama` for using local LLMs. Need to make sure the `Ollama API` is running. 

 - Now you can set the LLM models inside `config.py` as: 
 
 #### LLM Selection
    OLLAMA_LLM="llama3:8b"
    GROQ_LLM="llama3-8b-8192"
    OPENAI_LLM="gpt-4o"